### PR TITLE
Cy/fix 이슈 생성 필수값 조정, 이슈 조회 assignee 데이터 추가 조회

### DIFF
--- a/server/src/models/issue.ts
+++ b/server/src/models/issue.ts
@@ -21,7 +21,7 @@ Issue.init(
     },
     content: {
       type: DataTypes.TEXT,
-      allowNull: false,
+      allowNull: true,
     },
     is_open: {
       type: DataTypes.TINYINT,

--- a/server/src/service/issue/createIssue.ts
+++ b/server/src/service/issue/createIssue.ts
@@ -2,7 +2,7 @@ import Issue from '@models/issue';
 
 interface IssueProps {
   title: string;
-  content: string;
+  content?: string;
   milestoneId?: number;
   labelIds?: number[];
   assigneeIds?: number[];

--- a/server/src/service/issue/createIssue.ts
+++ b/server/src/service/issue/createIssue.ts
@@ -3,9 +3,9 @@ import Issue from '@models/issue';
 interface IssueProps {
   title: string;
   content: string;
-  milestoneId: number;
-  labelIds: number[];
-  assigneeIds: number[];
+  milestoneId?: number;
+  labelIds?: number[];
+  assigneeIds?: number[];
   userId: number;
 }
 
@@ -25,8 +25,13 @@ const createIssue = async (issue: IssueProps) => {
       user_id: userId,
       is_open: true,
     })) as IssueInstance;
-    await createdIssue.addLabels(labelIds);
-    await createdIssue.addAssignee(assigneeIds);
+
+    if (labelIds) {
+      await createdIssue.addLabels(labelIds);
+    }
+    if (assigneeIds) {
+      await createdIssue.addAssignee(assigneeIds);
+    }
 
     return createdIssue.id;
   } catch (error) {

--- a/server/src/service/issue/getIssue.ts
+++ b/server/src/service/issue/getIssue.ts
@@ -15,6 +15,14 @@ const getIssue = async (issueId: number) => {
           attributes: ['id', 'email', 'name', 'profile'],
         },
         {
+          model: User,
+          attributes: ['id', 'email', 'name', 'profile'],
+          as: 'Assignee',
+          through: {
+            attributes: [],
+          },
+        },
+        {
           model: Comment,
           attributes: ['id', 'content', 'created_at', 'updated_at'],
           include: [


### PR DESCRIPTION
### 이슈 생성 필수값 조정, 이슈 조회 assignee 데이터 추가 조회

- 이슈 생성 필수 값 조정
  - 이슈 생성 시 마일스톤, 레이블, assignee는 필수 항목이 아니므로 없을 경우를 고려 필수 값 조정
- 이슈 조회 시 assignee 데이터 추가 조회
  - 기존 서비스 로직에서 assignee 데이터가 조회되지 않아 sequelize의 join 추가 작성