### PR TITLE
Feature/API 버그 수정

### DIFF
--- a/server/src/api/routes/issue/controller/updateIssue.ts
+++ b/server/src/api/routes/issue/controller/updateIssue.ts
@@ -13,6 +13,8 @@ const updateIssue = async (req: Request, res: Response, next: NextFunction) => {
     updateResult = await issueService.updateIssueLabel(issueId, targets);
   }
   if (target === 'milestone') {
+    if (targets.length > 1) return res.status(400).json({ result: false });
+
     const milestoneId = targets[0];
     updateResult = issueService.updateIssueMilestone(issueId, milestoneId);
   }

--- a/server/src/api/routes/milestone/index.ts
+++ b/server/src/api/routes/milestone/index.ts
@@ -7,7 +7,7 @@ router.post('/', controllers.createMilestone);
 
 router.put('/:id', controllers.updateMilestone);
 
-router.put('/:id/status', controllers.updateMilestoneStatus);
+router.patch('/:id/status', controllers.updateMilestoneStatus);
 
 router.delete('/:id', controllers.deleteMilestone);
 

--- a/server/src/models/issue.ts
+++ b/server/src/models/issue.ts
@@ -21,7 +21,7 @@ Issue.init(
     },
     content: {
       type: DataTypes.TEXT,
-      allowNull: false,
+      allowNull: true,
     },
     is_open: {
       type: DataTypes.TINYINT,

--- a/server/src/service/issue/createIssue.ts
+++ b/server/src/service/issue/createIssue.ts
@@ -2,7 +2,7 @@ import Issue from '@models/issue';
 
 interface IssueProps {
   title: string;
-  content: string;
+  content?: string;
   milestoneId?: number;
   labelIds?: number[];
   assigneeIds?: number[];

--- a/server/src/service/issue/createIssue.ts
+++ b/server/src/service/issue/createIssue.ts
@@ -3,9 +3,9 @@ import Issue from '@models/issue';
 interface IssueProps {
   title: string;
   content: string;
-  milestoneId: number;
-  labelIds: number[];
-  assigneeIds: number[];
+  milestoneId?: number;
+  labelIds?: number[];
+  assigneeIds?: number[];
   userId: number;
 }
 
@@ -25,8 +25,13 @@ const createIssue = async (issue: IssueProps) => {
       user_id: userId,
       is_open: true,
     })) as IssueInstance;
-    await createdIssue.addLabels(labelIds);
-    await createdIssue.addAssignee(assigneeIds);
+
+    if (labelIds) {
+      await createdIssue.addLabels(labelIds);
+    }
+    if (assigneeIds) {
+      await createdIssue.addAssignee(assigneeIds);
+    }
 
     return createdIssue.id;
   } catch (error) {

--- a/server/src/service/issue/getIssue.ts
+++ b/server/src/service/issue/getIssue.ts
@@ -15,6 +15,14 @@ const getIssue = async (issueId: number) => {
           attributes: ['id', 'email', 'name', 'profile'],
         },
         {
+          model: User,
+          attributes: ['id', 'email', 'name', 'profile'],
+          as: 'Assignee',
+          through: {
+            attributes: [],
+          },
+        },
+        {
           model: Comment,
           attributes: ['id', 'content', 'created_at', 'updated_at'],
           include: [


### PR DESCRIPTION
### API 버그 수정

- 이슈 생성 필수 값 조정
  - 이슈 생성 시 마일스톤, 레이블, assignee는 필수 항목이 아니므로 없을 경우를 고려 필수 값 조정
- 이슈 조회 시 assignee 데이터 추가 조회
  - 기존 서비스 로직에서 assignee 데이터가 조회되지 않아 sequelize의 join 추가 작성

- issue milestone 변경 api 값 1개만 들어가도록 수정
- milestone 상태 변경 router 메소드 patch로 변경

#50 #51